### PR TITLE
Fix transmission 'config not found' error

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
     image : jaymoulin/transmission
     command: transmission-daemon -f -g /config
     volumes:
-      - ${STORAGE}/transmission:/config
+      - ./transmission:/config
       - ${STORAGE}/torrents:/downloads
     ports:
       - 9091:9091


### PR DESCRIPTION
The config file path was wrongly defined so the container was not being able to load the desire configs.